### PR TITLE
Update Sandbox NHS number to match NHS numbers in tests

### DIFF
--- a/api_tests/tests/reasonable_adjustment_flag/test_happy_cases.py
+++ b/api_tests/tests/reasonable_adjustment_flag/test_happy_cases.py
@@ -112,11 +112,6 @@ class TestHappyCasesSuite:
         consent_id = consent['id']
         version_id = consent['version']
 
-        # todo on sandbox the consent_id and version_id cannot be None, need a cleaner way to do this
-        if self.sandbox is True:
-            consent_id = '1'
-            version_id = 'W/"1"'
-
         # When
         response = requests.put(
             url=config.REASONABLE_ADJUSTMENTS_CONSENT + '/' + consent_id,
@@ -235,11 +230,6 @@ class TestHappyCasesSuite:
         flag_id = get_flag_response['id']
         version_id = get_flag_response['version']
 
-        # todo on sandbox the consent_id and version_id cannot be None, need a cleaner way to do this
-        if self.sandbox is True:
-            flag_id = '1'
-            version_id = 'W/"1"'
-
         # When
         response = requests.put(
             url=config.REASONABLE_ADJUSTMENTS_FLAG + '/' + flag_id,
@@ -320,14 +310,8 @@ class TestHappyCasesSuite:
 
         # Given
         expected_status_code = 200
-
-        # todo on sandbox the consent_id and version_id cannot be None, need a cleaner way to do this
-        if self.sandbox is True:
-            list_id = '1'
-            version_id = 'W/"1"'
-
-        reqBody = request_bank.get_body(Request.LIST_PUT)
-        reqBody['id'] = list_id
+        req_body = request_bank.get_body(Request.LIST_PUT)
+        req_body['id'] = list_id
 
         # When
         response = requests.put(
@@ -340,7 +324,7 @@ class TestHappyCasesSuite:
                 'accept': 'application/fhir+json',
                 'if-match': version_id,
             },
-            data=json.dumps(reqBody)
+            data=json.dumps(req_body)
         )
 
         # Then

--- a/api_tests/tests/reasonable_adjustment_flag/test_happy_cases.py
+++ b/api_tests/tests/reasonable_adjustment_flag/test_happy_cases.py
@@ -15,6 +15,7 @@ class TestHappyCasesSuite:
     """ A test suite to verify all the happy path endpoints """
 
     @pytest.mark.happy_path
+    @pytest.mark.sandbox
     @pytest.mark.integration
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_consent_get_without_consent(self):
@@ -134,6 +135,7 @@ class TestHappyCasesSuite:
 
     @pytest.mark.happy_path
     @pytest.mark.integration
+    @pytest.mark.sandbox
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_flag_get_without_flag(self):
         # Given
@@ -257,6 +259,7 @@ class TestHappyCasesSuite:
 
     @pytest.mark.happy_path
     @pytest.mark.integration
+    @pytest.mark.sandbox
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_list_get(self):
         # Given
@@ -307,6 +310,7 @@ class TestHappyCasesSuite:
         assert_that(expected_status_code).is_equal_to(response.status_code)
 
     @pytest.mark.happy_path
+    @pytest.mark.sandbox
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_list_put(self):
         # Pre-Req

--- a/api_tests/tests/reasonable_adjustment_flag/test_happy_cases.py
+++ b/api_tests/tests/reasonable_adjustment_flag/test_happy_cases.py
@@ -15,7 +15,6 @@ class TestHappyCasesSuite:
     """ A test suite to verify all the happy path endpoints """
 
     @pytest.mark.happy_path
-    @pytest.mark.sandbox
     @pytest.mark.integration
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_consent_get_without_consent(self):
@@ -45,6 +44,7 @@ class TestHappyCasesSuite:
         assert_that(result_dict['total']).is_equal_to(0) # Validate patient record does not contain a consent flag
 
     @pytest.mark.happy_path
+    @pytest.mark.sandbox
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_consent_get_with_consent(self):
         # Pre-Req
@@ -135,7 +135,6 @@ class TestHappyCasesSuite:
 
     @pytest.mark.happy_path
     @pytest.mark.integration
-    @pytest.mark.sandbox
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_flag_get_without_flag(self):
         # Given
@@ -164,6 +163,7 @@ class TestHappyCasesSuite:
         assert_that(result_dict['total']).is_equal_to(0)  # Validate patient record does not contain a consent flag
 
     @pytest.mark.happy_path
+    @pytest.mark.sandbox
     @pytest.mark.usefixtures('get_token_internal_dev')
     def test_flag_get_with_flag(self):
         # Pre-Req: Patient record with both a consent and flag
@@ -320,17 +320,18 @@ class TestHappyCasesSuite:
 
         # Given
         expected_status_code = 200
-        json = request_bank.get_body(Request.LIST_PUT)
-        json['id'] = list_id
 
         # todo on sandbox the consent_id and version_id cannot be None, need a cleaner way to do this
         if self.sandbox is True:
             list_id = '1'
             version_id = 'W/"1"'
 
+        reqBody = request_bank.get_body(Request.LIST_PUT)
+        reqBody['id'] = list_id
+
         # When
         response = requests.put(
-            url=config.REASONABLE_ADJUSTMENTS_LIST + list_id,
+            url=config.REASONABLE_ADJUSTMENTS_LIST + '/' + list_id,
             headers={
                 'Authorization': f'Bearer {self.token}',
                 'nhsd-session-urid': config.TEST_NHSD_SESSION_URID,
@@ -339,7 +340,7 @@ class TestHappyCasesSuite:
                 'accept': 'application/fhir+json',
                 'if-match': version_id,
             },
-            data=json
+            data=json.dumps(reqBody)
         )
 
         # Then

--- a/docker/reasonable-adjustment-flag-sandbox/src/mocks/consentGET.json
+++ b/docker/reasonable-adjustment-flag-sandbox/src/mocks/consentGET.json
@@ -1,134 +1,126 @@
 {
-    "resourceType": "Bundle",
-    "id": "2dce9ecf-75c6-4ad5-a770-4f035419c229",
-    "meta": {
-      "profile": [
-        "http://hl7.org/fhir/bundle"
-      ]
-    },
-    "type": "searchset",
-    "total": 1,
-    "link": [
-      {
-        "relation": "self",
-        "url": "https://clinicals.spineservices.nhs.uk/STU3/Consent?patient=999999998&status=active&category=https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-FlagCategory-1|reasonable%20adjustments%20flag&_format=json"
-      }
-    ],
-    "entry": [
-      {
-        "fullUrl": "https://clinicals.spineservices.nhs.uk/STU3/Consent/f1dc0ac6-45ff-4d2b-bf91-793971e3e286",
-        "resource": {
-          "resourceType": "Consent",
-          "id": "f1dc0ac6-45ff-4d2b-bf91-793971e3e286",
-          "meta": {
-            "versionId": "1fc6e241-89f5-4ba4-b957-f025f21854c3",
-            "lastUpdated": "2018-03-01T10:00:00+00:00",
-            "profile": [
-              "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Consent-1"
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/bundle"
+    ]
+  },
+  "link": [
+    {
+      "url": "https://internet_mps/STU3/Consent?category=https%3A%2F%2Ffhir.nhs.uk%2FSTU3%2FCodeSystem%2FRARecord-FlagCategory-1%7CNRAF&status=active&patient=9692247317",
+      "relation": "self"
+    }
+  ],
+  "entry": [
+    {
+      "resource": {
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "NRAF",
+                "display": "National Reasonable Adjustments Flag",
+                "system": "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-FlagCategory-1"
+              }
             ]
-          },
-          "contained": [
-            {
-              "resourceType": "Provenance",
-              "id": "e0531fd1-212d-4a97-a7a9-d17cec9a6af2",
-              "meta": {
-                "profile": [
-                  "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Provenance-1"
-                ]
-              },
-              "target": [
+          }
+        ],
+        "status": "active",
+        "patient": {
+          "reference": "https://demographics.spineservices.nhs.uk/STU3/Patient/9692247317"
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-ProxyRole-1",
+            "valueCodeableConcept": {
+              "coding": [
                 {
-                  "reference": "Consent/f1dc0ac6-45ff-4d2b-bf91-793971e3e286"
-                }
-              ],
-              "recorded": "2016-03-01T10:05:33+00:00",
-              "agent": [
-                {
-                  "role": [
-                    {
-                      "coding": [
-                        {
-                          "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1",
-                          "code": "R0260",
-                          "display": "General Medical Practitioner"
-                        }
-                      ]
-                    }
-                  ],
-                  "whoReference": {
-                    "reference": "https://sds.spineservices.nhs.uk/STU3/Practitioner/2ee4tr6a9",
-                    "display": "Dr.D"
-                  },
-                  "onBehalfOfReference": {
-                    "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/a3e5i7",
-                    "display": "Some GP Clinic"
-                  }
+                  "code": "001",
+                  "display": "Patient consent",
+                  "system": "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-ProxyRole-1"
                 }
               ]
             }
-          ],
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-ProxyRole-1",
-              "valueCodeableConcept": {
-                "coding": [
+          },
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-Provenance-1",
+            "extension": [
+              {
+                "url": "Created",
+                "valueReference": {
+                  "reference": "#0719ef10-346e-4378-8bf3-d878e0defbd8"
+                }
+              }
+            ]
+          }
+        ],
+        "resourceType": "Consent",
+        "contained": [
+          {
+            "target": [
+              {
+                "reference": "Consent/9692247317.f270f3b1-b474-443a-9958-7fe7e92e9614"
+              }
+            ],
+            "resourceType": "Provenance",
+            "recorded": "2021-02-25T10:35:41+00:00",
+            "agent": [
+              {
+                "onBehalfOfReference": {
+                  "display": "WEST POTTERGATE HLTH CTR (D82106)",
+                  "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/D82106"
+                },
+                "whoReference": {
+                  "display": "Healthchecks,Morning",
+                  "reference": "https://sds.spineservices.nhs.uk/STU3/Practitioner/093895563513"
+                },
+                "role": [
                   {
-                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-ProxyRole-1",
-                    "code": "lpa",
-                    "display": "Lasting power of attorney personal welfare"
+                    "coding": [
+                      {
+                        "code": "R0050",
+                        "display": "Consultant",
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1"
+                      }
+                    ]
                   }
                 ]
               }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Provenance-1"
+              ]
             },
-            {
-              "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-Provenance-1",
-              "extension": [
-                {
-                  "url": "created",
-                  "valueReference": {
-                    "reference": "#e0531fd1-212d-4a97-a7a9-d17cec9a6af2"
-                  }
-                }
-              ]
-            }
+            "id": "0719ef10-346e-4378-8bf3-d878e0defbd8"
+          }
+        ],
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Consent-1"
           ],
-          "status": "active",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-FlagCategory-1",
-                  "code": "reasonable adjustments flag",
-                  "display": "Reasonable Adjustments Flag"
-                }
-              ]
-            }
-          ],
-          "patient": {
-            "identifier": [
-            {
-              "system": "https://fhir.nhs.uk/Id/nhs-number",
-              "value": "999999998"
-            }
-          ]
+          "versionId": "1",
+          "lastUpdated": "2021-02-25T10:35:41+00:00"
         },
-          "policy": [
-            {
-              "authority": "https://www.gov.uk/",
-              "uri": "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/535024/data-security-review.pdf"
-            }
-          ],
-          "purpose": [
-            {
-              "system": "https://snomed.info/sct",
-              "code": "370856009",
-              "display": "Limiting access to confidential patient information"
-            }
-          ]
-        },
-        "search": {
-          "mode": "match"
-        }
-      }
-    ]
-  }
+        "purpose": [
+          {
+            "code": "RACONSENT",
+            "display": "Reasonable Adjustments - Consent to record Reasonable Adjustments",
+            "system": "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-ConsentPurpose-1"
+          }
+        ],
+        "policy": [
+          {
+            "uri": "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/535024/data-security-review.pdf",
+            "authority": "https://www.gov.uk/"
+          }
+        ],
+        "id": "9692247317.f270f3b1-b474-443a-9958-7fe7e92e9614"
+      },
+      "fullUrl": "https://clinicals.spineservices.nhs.uk/STU3/Consent/9692247317.f270f3b1-b474-443a-9958-7fe7e92e9614"
+    }
+  ],
+  "total": 1,
+  "type": "searchset",
+  "id": "d17a5816-87a6-418d-8c9a-fe2d652b6d99"
+}

--- a/docker/reasonable-adjustment-flag-sandbox/src/mocks/flagGET.json
+++ b/docker/reasonable-adjustment-flag-sandbox/src/mocks/flagGET.json
@@ -1,75 +1,46 @@
 {
   "resourceType": "Bundle",
-  "id": "fda1cad0-ba84-11e8-96f8-529269fb1459",
-  "type": "searchset",
-  "total": 1,
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/bundle"
+    ]
+  },
   "link": [
     {
-      "relation": "self",
-      "url": "https://clinicals.spineservices.nhs.uk/STU3/Flag?patient=999999998&status=active&category=https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-FlagCategory-1|reasonable%20adjustments%20flag&_format=xml"
+      "url": "https://internet_mps/STU3/Flag?patient=9692247317&category=https%3A%2F%2Ffhir.nhs.uk%2FSTU3%2FCodeSystem%2FRARecord-FlagCategory-1%7CNRAF&status=active",
+      "relation": "self"
     }
   ],
   "entry": [
     {
-      "fullUrl": "https://clinicals.spineservices.nhs.uk/STU3/Flag/9e63f370-ba72-11e8-96f8-529269fb1459",
       "resource": {
-        "resourceType": "Flag",
-        "id": "9e63f370-ba72-11e8-96f8-529269fb1459",
-        "meta": {
-          "versionId": "2042385c-ba73-11e8-96f8-529269fb1459",
-          "lastUpdated": "2018-07-24T10:01:00+00:00",
-          "profile": [
-            "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Flag-1"
+        "category": {
+          "coding": [
+            {
+              "code": "NRAF",
+              "display": "National Reasonable Adjustments Flag",
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-FlagCategory-1"
+            }
           ]
         },
-        "contained": [
-          {
-            "resourceType": "Provenance",
-            "id": "2042526a-ba73-11e8-96f8-529269fb1459",
-            "meta": {
-              "profile": [
-                "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Provenance-1"
-              ]
-            },
-            "target": [
-              {
-                "reference": "Flag/9e63f370-ba72-11e8-96f8-529269fb1459"
-              }
-            ],
-            "recorded": "2018-07-24T10:01:00+00:00",
-            "agent": [
-              {
-                "role": [
-                  {
-                    "coding": [
-                      {
-                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1",
-                        "code": "R1974",
-                        "display": "Community Learning Disabilities Nurse"
-                      }
-                    ]
-                  }
-                ],
-                "whoReference": {
-                  "reference": "https://sds.spineservices.nhs.uk/STU3/Practitioner/4tr6ee6a9",
-                  "display": "Nurse N"
-                },
-                "onBehalfOfReference": {
-                  "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/a3e5i7",
-                  "display": "Some Hospital Learning Disability Support Department"
-                }
-              }
-            ]
-          }
-        ],
+        "status": "active",
+        "code": {
+          "coding": [
+            {
+              "code": "945951000000108",
+              "display": "Requires visual alert",
+              "system": "https://snomed.info/sct"
+            }
+          ]
+        },
         "extension": [
           {
             "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-Provenance-1",
             "extension": [
               {
-                "url": "created",
+                "url": "Created",
                 "valueReference": {
-                  "reference": "#2042526a-ba73-11e8-96f8-529269fb1459"
+                  "reference": "#0719ef10-346e-4378-8bf3-d878e0defbd8"
                 }
               }
             ]
@@ -79,42 +50,120 @@
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-AdjustmentCategories-1",
-                  "code": "comms",
-                  "display": "Communication"
+                  "code": "003",
+                  "display": "Accessible Information - requires specific contact method",
+                  "system": "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-AdjustmentCategory-1"
                 }
               ]
             }
+          },
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-Provenance-1",
+            "extension": [
+              {
+                "url": "Created",
+                "valueReference": {
+                  "reference": "#0719ef10-346e-4378-8bf3-d878e0defbd8"
+                }
+              }
+            ]
           }
         ],
-        "status": "active",
-        "category": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-FlagCategory-1",
-              "code": "reasonable adjustments flag",
-              "display": "Reasonable Adjustments Flag"
-            }
-          ]
-        },
-        "code": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-AccessibleInformationAdjustments-1",
-              "code": "requiresinformationineasyread",
-              "display": "Requires information in Easyread"
-            }
-          ]
-        },
-        "patient": {
-          "identifier": [
+        "resourceType": "Flag",
+        "contained": [
           {
-            "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "999999998"
+            "target": [
+              {
+                "reference": "Flag/9692247317.a54f7fe6-fb35-4fef-a2dc-7a9df9ee7441"
+              }
+            ],
+            "resourceType": "Provenance",
+            "recorded": "2021-02-25T10:37:47+00:00",
+            "agent": [
+              {
+                "onBehalfOfReference": {
+                  "display": "WEST POTTERGATE HLTH CTR (D82106)",
+                  "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/D82106"
+                },
+                "whoReference": {
+                  "display": "Healthchecks,Morning",
+                  "reference": "https://sds.spineservices.nhs.uk/STU3/Practitioner/093895563513"
+                },
+                "role": [
+                  {
+                    "coding": [
+                      {
+                        "code": "R0050",
+                        "display": "Consultant",
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Provenance-1"
+              ]
+            },
+            "id": "0719ef10-346e-4378-8bf3-d878e0defbd8"
+          },
+          {
+            "target": [
+              {
+                "reference": "Flag/9692247317.a54f7fe6-fb35-4fef-a2dc-7a9df9ee7441"
+              }
+            ],
+            "resourceType": "Provenance",
+            "recorded": "2021-02-25T10:37:47+00:00",
+            "agent": [
+              {
+                "onBehalfOfReference": {
+                  "display": "WEST POTTERGATE HLTH CTR (D82106)",
+                  "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/D82106"
+                },
+                "whoReference": {
+                  "display": "Healthchecks,Morning",
+                  "reference": "https://sds.spineservices.nhs.uk/STU3/Practitioner/093895563513"
+                },
+                "role": [
+                  {
+                    "coding": [
+                      {
+                        "code": "R0050",
+                        "display": "Consultant",
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Provenance-1"
+              ]
+            },
+            "id": "0719ef10-346e-4378-8bf3-d878e0defbd8"
           }
-        ]
+        ],
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Flag-1"
+          ],
+          "versionId": "1",
+          "lastUpdated": "2021-02-25T10:37:47+00:00"
+        },
+        "id": "9692247317.a54f7fe6-fb35-4fef-a2dc-7a9df9ee7441",
+        "subject": {
+          "reference": "https://demographics.spineservices.nhs.uk/STU3/Patient/9692247317"
         }
-      }
+      },
+      "fullUrl": "https://clinicals.spineservices.nhs.uk/STU3/Flag/9692247317.a54f7fe6-fb35-4fef-a2dc-7a9df9ee7441"
     }
-  ]
+  ],
+  "total": 1,
+  "type": "searchset",
+  "id": "a469d5f5-fb54-4087-90e5-20e260a1606b"
 }

--- a/docker/reasonable-adjustment-flag-sandbox/src/mocks/listGET.json
+++ b/docker/reasonable-adjustment-flag-sandbox/src/mocks/listGET.json
@@ -1,140 +1,155 @@
 {
-  "Bundle": {
-    "-xmlns": "http://hl7.org/fhir",
-    "id": "b45afdbc-cce1-4623-8942-2ec3baf879e7",
-    "meta": {
-      "profile": "http://hl7.org/fhir/bundle"
-    },
-    "type": "searchset",
-    "total": "1",
-    "link": {
-      "relation": "self",
-      "url": "https://clinicals.spineservices.nhs.uk/STU3/List?patient=999999998&status=current&code=http://snomed.info/sct|1094391000000102&_format=xml"
-    },
-    "entry": {
-      "fullUrl": "https://clinicals.spineservices.nhs.uk/STU3/List/e00c5a85-d34f-4075-96ac-b787deb484b1",
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/bundle"
+    ]
+  },
+  "link": [
+    {
+      "url": "https://internet_mps/STU3/List?patient=9692247317&status=active&code=http%3A%2F%2Fsnomed.info%2Fsct%7C1094391000000102",
+      "relation": "self"
+    }
+  ],
+  "entry": [
+    {
       "resource": {
-        "List": {
-          "-xmlns": "http://hl7.org/fhir",
-          "id": "130f416a-055d-4a5d-a453-2b7c2de3b57b",
-          "meta": {
-            "versionId": "f2fef5e5-c38a-408c-a9bc-2d49923928f8",
-            "profile": "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-RARecord-List-1"
-          },
-          "contained": [
+        "status": "current",
+        "code": {
+          "coding": [
             {
-              "Condition": {
-                "-xmlns": "http://hl7.org/fhir",
-                "id": "57f04652-6dd0-4135-a560-f9091b1b26fa",
-                "meta": {
-                  "versionId": "557ccfc3-0c78-48bf-aedd-70cc08af2ba1",
-                  "lastUpdated": "2018-07-23T11:00:00+00:00",
-                  "profile": "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-RARecord-Condition-1"
-                },
-                "extension": {
-                  "-url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-Provenance-1",
-                  "extension": {
-                    "-url": "created",
-                    "valueReference": {
-                      "reference": "urn:uuid:8ce7de6b-1307-432d-8e96-ae6a613ca3e4"
-                    }
-                  }
-                },
-                "clinicalStatus": "active",
-                "category": {
-                  "coding": {
-                    "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/CareConnect-ConditionCategory-1",
-                    "code": "issue",
-                    "display": "Issue"
-                  }
-                },
-                "code": {
-                  "coding": {
-                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CodeSystem-RARecord-ConditionCode-1",
-                    "code": "1855002",
-                    "display": "Learning Disability(s)"
-                  }
-                },
-                "patient": {
-                  "identifier": [
+              "code": "1094391000000102",
+              "display": "Reasonable adjustments for health and care access",
+              "system": "http://snomed.info/sct"
+            }
+          ]
+        },
+        "title": "Reasonable Adjustment List",
+        "resourceType": "List",
+        "contained": [
+          {
+            "category": [
+              {
+                "coding": [
                   {
-                    "system": "https://fhir.nhs.uk/Id/nhs-number",
-                    "value": "999999998"
+                    "code": "issue",
+                    "display": "Issue",
+                    "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/CareConnect-ConditionCategory-1"
                   }
                 ]
-                }
               }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "code": "01",
+                  "display": "Impairment related to autism (Equality Act 2010)",
+                  "system": "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-ConditionCode-1"
+                }
+              ]
             },
-            {
-              "Provenance": {
-                "id": "8ce7de6b-1307-432d-8e96-ae6a613ca3e4",
-                "meta": {
-                  "profile": "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Provenance-1"
-                },
-                "target": {
-                  "reference": "Condition/57f04652-6dd0-4135-a560-f9091b1b26fa"
-                },
-                "recorded": "2018-07-23T11:00:00+00:00",
-                "agent": {
-                  "role": {
-                    "coding": {
-                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1",
-                      "code": "R0260",
-                      "display": "General Medical Practitioner"
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-RARecord-Provenance-1",
+                "extension": [
+                  {
+                    "url": "created",
+                    "valueReference": {
+                      "reference": "Provenance/8ce7de6b-1307-432d-8e96-ae6a613ca3e4"
                     }
-                  },
-                  "whoReference": {
-                    "reference": "https://sds.spineservices.nhs.uk/STU3/Practitioner/2ee4tr6a9",
-                    "display": "Dr.D"
-                  },
-                  "onBehalfOfReference": {
-                    "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/a3e5i7",
-                    "display": "Some GP Clinic"
                   }
-                }
+                ]
               }
-            }
-          ],
-          "status": "current",
-          "mode": "changes",
-          "title": "Reasonable Adjustment List",
-          "code": {
-            "coding": {
-              "system": "http://snomed.info/sct",
-              "code": "1094391000000102",
-              "display": "Reasonable adjustments for health and care access"
-            }
-          },
-          "patient": {
-            "identifier": [
-            {
-              "system": "https://fhir.nhs.uk/Id/nhs-number",
-              "value": "999999998"
-            }
-          ]
-          },
-          "date": "2018-07-23T11:00:00+00:00",
-          "entry": [
-            {
-              "deleted": "false",
-              "date": "2018-07-23T11:00:00+00:00",
-              "item": {
-                "reference": "urn:uuid:557ccfc3-0c78-48bf-aedd-70cc08af2ba1"
+            ],
+            "resourceType": "Condition",
+            "clinicalStatus": "active",
+            "note": [
+              {
+                "text": "Some notes"
               }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-RARecord-Condition-1"
+              ]
             },
-            {
-              "deleted": "false",
-              "date": "2018-07-23T11:00:00+00:00",
-              "item": {
-                "reference": "urn:uuid:8ce7de6b-1307-432d-8e96-ae6a613ca3e4"
-              }
+            "id": "57f04652-6dd0-4135-a560-f9091b1b26fa",
+            "subject": {
+              "reference": "https://demographics.spineservices.nhs.uk/STU3/Patient/9692247317"
             }
-          ]
+          },
+          {
+            "target": [
+              {
+                "reference": "Condition/57f04652-6dd0-4135-a560-f9091b1b26fa"
+              }
+            ],
+            "resourceType": "Provenance",
+            "recorded": "2021-02-25T10:39:10+00:00",
+            "agent": [
+              {
+                "onBehalfOfReference": {
+                  "display": "WEST POTTERGATE HLTH CTR (D82106)",
+                  "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/D82106"
+                },
+                "whoReference": {
+                  "display": "Healthchecks,Morning",
+                  "reference": "https://sds.spineservices.nhs.uk/STU3/Practitioner/093895563513"
+                },
+                "role": [
+                  {
+                    "coding": [
+                      {
+                        "code": "R0050",
+                        "display": "Consultant",
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/RARecord-Provenance-1"
+              ]
+            },
+            "id": "8ce7de6b-1307-432d-8e96-ae6a613ca3e4"
+          }
+        ],
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-RARecord-List-1"
+          ],
+          "versionId": "71502f39-cede-4c73-9545-57406beabebe"
+        },
+        "mode": "changes",
+        "date": "2018-07-23T11:00:00+00:00",
+        "entry": [
+          {
+            "date": "2021-02-25T10:39:10+00:00",
+            "deleted": false,
+            "item": {
+              "reference": "#57f04652-6dd0-4135-a560-f9091b1b26fa"
+            }
+          },
+          {
+            "date": "2021-02-25T10:39:10+00:00",
+            "deleted": false,
+            "item": {
+              "reference": "#8ce7de6b-1307-432d-8e96-ae6a613ca3e4"
+            }
+          }
+        ],
+        "id": "9692247317.756f0a10-f092-49be-9881-c4e53c86ae09",
+        "subject": {
+          "reference": "https://demographics.spineservices.nhs.uk/STU3/Patient/9692247317"
         }
       },
-      "search": {
-        "mode": "match"
-      }
+      "fullUrl": "https://clinicals.spineservices.nhs.uk/STU3/List/9692247317.756f0a10-f092-49be-9881-c4e53c86ae09"
     }
-  }
+  ],
+  "total": 1,
+  "type": "searchset",
+  "id": "36933445-44b0-4ea0-a9cd-ff88e65122fc"
 }

--- a/docker/reasonable-adjustment-flag-sandbox/src/routes/consentEndpoint.js
+++ b/docker/reasonable-adjustment-flag-sandbox/src/routes/consentEndpoint.js
@@ -2,7 +2,7 @@ const consentGet =  {
     method: 'GET',
     path: '/Consent',
     handler: (request, h) => {
-        if (request.query["patient"] != '9999999998') {
+        if (request.query["patient"] != '9692247317') {
             const path = 'consentGETerror.json'
             return h.response(h.file(path)).code(404);
         }

--- a/docker/reasonable-adjustment-flag-sandbox/src/routes/flagEndpoint.js
+++ b/docker/reasonable-adjustment-flag-sandbox/src/routes/flagEndpoint.js
@@ -2,7 +2,7 @@ const flagGet =  {
     method: 'GET',
     path: '/Flag',
     handler: (request, h) => {
-        if (request.query["patient"] != '9999999998') {
+        if (request.query["patient"] != '9692247317') {
             const path = 'flagGETerror.json'
             return h.response(h.file(path)).code(404);
         }

--- a/docker/reasonable-adjustment-flag-sandbox/src/routes/listEndpoint.js
+++ b/docker/reasonable-adjustment-flag-sandbox/src/routes/listEndpoint.js
@@ -2,7 +2,7 @@ const listGet =  {
     method: 'GET',
     path: '/List',
     handler: (request, h) => {
-        if (request.query["patient"] != '9999999998') {
+        if (request.query["patient"] != '9692247317') {
             const path = 'listGETerror.json'
             return h.response(h.file(path)).code(404);
         }

--- a/specification/reasonable-adjustment-flag.yaml
+++ b/specification/reasonable-adjustment-flag.yaml
@@ -924,7 +924,7 @@ components:
       description: 'The patient''s NHS number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a [valid NHS number](https://datadictionary.nhs.uk/attributes/nhs_number.html).'
       schema:
         type: string
-        example: '9999999998'
+        example: '9692247317'
     status:
       name: status
       in: query


### PR DESCRIPTION
## Summary
* Routine Change

1. - Updated the NHS number in the Sandbox to match the NHS number used by the integration tests, in order to allow us test that the Sandbox is working by running the integration tests
2. - Updated the responses returned by the Sandbox for GET `/Consent`, `/List` &` /Flag` to match the RA API


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
