### PR TITLE
Added support for NHSD-Correlation-ID header

### DIFF
--- a/api_tests/tests/utils.py
+++ b/api_tests/tests/utils.py
@@ -35,6 +35,7 @@ class Utils:
                 'Authorization': f'Bearer {self.token}',
                 'nhsd-session-urid': 'test',
                 'x-request-id': str(uuid.uuid4()),
+                'x-correlation-id': str(uuid.uuid4())
             }
         )
 

--- a/proxies/live/apiproxy/policies/AssignMessage.AddHeaders.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddHeaders.xml
@@ -4,6 +4,7 @@
     <Headers>
       <Header name="NHSD-ASID">{verifyapikey.VerifyAPIKey.CustomAttributes.asid}</Header>
       <Header name="NHSD-Request-ID">{request.header.X-Request-ID}</Header>
+      <Header name="NHSD-Correlation-ID">{request.header.X-Request-ID}.{request.header.X-Correlation-ID}.{messageid}</Header>
     </Headers>
   </Set>
   <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>

--- a/proxies/live/apiproxy/policies/AssignMessage.Copy.RequestHeaders.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Copy.RequestHeaders.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.Copy.RequestHeaders">
+    <DisplayName>AssignMessage.Copy.RequestHeaders</DisplayName>
+    <Properties/>
+    <Copy source="request">
+        <Headers>
+            <Header name="X-Request-ID"/>
+            <Header name="X-Correlation-ID"/>
+        </Headers>
+    </Copy>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <AssignTo createNew="true" transport="http" type="request">original-request-details</AssignTo>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/AssignMessage.Mirror.CorrelationID.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Mirror.CorrelationID.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.Mirror.CorrelationID">
+    <DisplayName>AssignMessage.Mirror.CorrelationID</DisplayName>
+    <Set>
+        <Headers>
+            <Header name="X-Correlation-ID">{original-request-details.header.X-Correlation-ID}</Header>
+        </Headers>
+    </Set>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <AssignTo createNew="false" transport="http" type="request"/>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/AssignMessage.Mirror.RequestID.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Mirror.RequestID.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.Mirror.RequestID">
+    <DisplayName>AssignMessage.Mirror.RequestID</DisplayName>
+    <Set>
+        <Headers>
+            <Header name="X-Request-ID">{original-request-details.header.X-Request-ID}</Header>
+        </Headers>
+    </Set>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <AssignTo createNew="false" transport="http" type="request"/>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/AssignMessage.RemoveHeaders.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.RemoveHeaders.xml
@@ -3,6 +3,7 @@
   <Remove>
     <Headers>
       <Header name="Authorization"/>
+      <Header name="X-Correlation-ID"/>
       <Header name="X-Request-ID"/>
     </Headers>
   </Remove>

--- a/proxies/live/apiproxy/targets/ig3.xml
+++ b/proxies/live/apiproxy/targets/ig3.xml
@@ -31,6 +31,9 @@
             <Step>
               <Name>JavaScript.CreateClaimVars</Name>
             </Step>
+             <Step>
+              <Name>AssignMessage.Copy.RequestHeaders</Name>
+            </Step>
             <Step>
               <Name>AssignMessage.AddHeaders</Name>
             </Step>
@@ -49,6 +52,14 @@
     </PreFlow>
     <PostFlow>
         <Response>
+            <Step>
+                <Name>AssignMessage.Mirror.CorrelationID</Name>
+                <Condition>(original-request-details.header.X-Correlation-ID ~~ ".+")</Condition>
+            </Step>
+            <Step>
+                <Name>AssignMessage.Mirror.RequestID</Name>
+                <Condition>(original-request-details.header.X-Request-ID ~~ ".+")</Condition>
+            </Step>
             <Step>
                 <Name>ExtractVariable.GetContentLocation</Name>
             </Step>


### PR DESCRIPTION
## Summary
* Routine Change

Mapped the incoming request header `X-Correlation-ID` to the outgoing request header `NHSD-Correlation-ID`


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
